### PR TITLE
Change brewing stand storage file delimiter to @

### DIFF
--- a/src/main/java/us/eunoians/mcrpg/McRPG.java
+++ b/src/main/java/us/eunoians/mcrpg/McRPG.java
@@ -131,6 +131,7 @@ public class McRPG extends JavaPlugin {//implements //Initializable {
     leaderboardHeadManager = new LeaderboardHeadManager();
     Metrics metrics = new Metrics(this, id);
     brewingStandManager = new BrewingStandManager();
+    brewingStandManager.updateNamingFormat();
     getLogger().info("Loading Potions");
     potionRecipeManager = new PotionRecipeManager();
     new PlayerManager(this);

--- a/src/main/java/us/eunoians/mcrpg/api/util/Methods.java
+++ b/src/main/java/us/eunoians/mcrpg/api/util/Methods.java
@@ -306,7 +306,8 @@ public class Methods {
   }
 
   public static String chunkToLoc(Chunk chunk){
-    return chunk.getX() + ":" + chunk.getZ() + ":" + chunk.getWorld().getName();
+    // use @ instead of : as delimiters here because Windows doesn't like colons in filenames
+    return chunk.getX() + "@" + chunk.getZ() + "@" + chunk.getWorld().getName();
   }
 
   public static Location stringToLoc(String loc) {

--- a/src/main/java/us/eunoians/mcrpg/api/util/brewing/BrewingStandManager.java
+++ b/src/main/java/us/eunoians/mcrpg/api/util/brewing/BrewingStandManager.java
@@ -12,8 +12,11 @@ import us.eunoians.mcrpg.api.util.brewing.standmeta.BrewingStandWrapper;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class BrewingStandManager {
 
@@ -103,6 +106,26 @@ public class BrewingStandManager {
   public void shutDown(){
     for(FileWrapper fileWrapper : chunkToSaveFile.values()){
       fileWrapper.save();
+    }
+  }
+
+  /**
+   * This method was written to be used for conversion from pre-1.2.4 brewing stand file naming to 1.2.4
+   * Prior to 1.2.4, the brewing stand file names used colons (":") as delimiters. This was incompatible with Windows.
+   * In 1.2.4, this behavior was changed to use at symbols ("@") as delimiters, which is compatible with Windows.
+   */
+  public void updateNamingFormat() {
+    File folder = new File(McRPG.getInstance().getDataFolder(), "brewing_storage");
+    if (folder.exists()) {
+      File[] files = folder.listFiles();
+      if (files != null && files.length > 0) {
+        List<File> filesToRename = Arrays.stream(files).filter(f -> f.getName().contains(":")).collect(Collectors.toList());
+        if (filesToRename.size() > 0) {
+          McRPG.getInstance().getLogger().info("Found pre-1.2.4 brewing stand storage format. Converting...");
+          filesToRename.forEach(f -> f.renameTo(new File(folder, f.getName().replaceAll(":", "@"))));
+          McRPG.getInstance().getLogger().info("1.2.4 brewing stand storage format converted successfully!");
+        }
+      }
     }
   }
   

--- a/src/main/java/us/eunoians/mcrpg/api/util/brewing/BrewingStandManager.java
+++ b/src/main/java/us/eunoians/mcrpg/api/util/brewing/BrewingStandManager.java
@@ -12,6 +12,7 @@ import us.eunoians.mcrpg.api.util.brewing.standmeta.BrewingStandWrapper;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -122,7 +123,13 @@ public class BrewingStandManager {
         List<File> filesToRename = Arrays.stream(files).filter(f -> f.getName().contains(":")).collect(Collectors.toList());
         if (filesToRename.size() > 0) {
           McRPG.getInstance().getLogger().info("Found pre-1.2.4 brewing stand storage format. Converting...");
-          filesToRename.forEach(f -> f.renameTo(new File(folder, f.getName().replaceAll(":", "@"))));
+          filesToRename.forEach(f -> {
+            try {
+              Files.move(f.toPath(), f.toPath().resolveSibling(f.getName().replaceAll(":", "@")));
+            } catch (IOException e) {
+              e.printStackTrace();
+            }
+          });
           McRPG.getInstance().getLogger().info("1.2.4 brewing stand storage format converted successfully!");
         }
       }


### PR DESCRIPTION
This PR changes the storage file delimiter for brewing stands to "@" instead of ":". This will fix the issue where brewing stand storage does not work properly on Windows-based servers. I also added conversion logic that occurs on server startup, to convert from the old format to the new.